### PR TITLE
Detecting Namoroka

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -160,7 +160,7 @@ sub _test {
     $self->{tests} = {};
     my $tests = $self->{tests};
 
-    my @ff = qw( firefox firebird iceweasel phoenix );
+    my @ff = qw( firefox firebird iceweasel phoenix namoroka );
     my $ff = join "|", @ff;
 
     my $ua = lc $self->{user_agent};

--- a/t/useragents.yaml
+++ b/t/useragents.yaml
@@ -2271,3 +2271,18 @@ match:
 minor: 0
 no_match:
   - robot
+---
+useragent: 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.16pre) Gecko/20110308 Ubuntu/10.10 (maverick) Namoroka/3.6.16pre'
+match:
+  - linux
+  - unix
+  - x11
+  - firefox
+browser_string: Firefox
+os: Linux
+public_version: 3.6
+public_major: 3
+public_minor: 0.6
+engine_version: 1.9
+engine_major: 1
+engine_minor: 0.9


### PR DESCRIPTION
I just noticed that under Ubuntu 10.10 Firefox is not correctly detected. It's due to 'Namoroka' name, that looks like a 3.6 dev release from here http://www.zytrax.com/tech/web/browser_ids.htm.
