### PR TITLE
mobile robots

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -524,6 +524,8 @@ sub _test {
             || index( $ua, "fennec" ) != -1
             || index( $ua, "opera tablet" ) != -1
             || $tests->{PSP}
+            || $tests->{GOOGLEMOBILE}
+            || $tests->{MSNMOBILE}
     );
 
     # Operating System

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2565,6 +2565,7 @@
       "match" : [
          "googlemobile",
          "google",
+         "mobile",
          "robot"
       ],
       "minor" : ".1",


### PR DESCRIPTION
Hello Olaf,

this is regarding #12.

I found checks for googlemobile and msnmobile and I think these should set mobile to 1 too. Because I might redirect my website to the mobile version (and Google should index that too).

I'm fine if you reject the patch. I will then change my website to use ->mobile || ->googlemobile.

Bye, Uwe
