### PR TITLE
Add methods for new Internet Explorer versions

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -48,15 +48,15 @@ push @ALL_TESTS, qw(
     ie3         ie4         ie4up
     ie5         ie5up       ie55
     ie55up      ie6         ie7
-    ie8         ie9         opera
-    opera3      opera4      opera5
-    opera6      opera7      lynx
-    links       aol         aol3
-    aol4        aol5        aol6
-    neoplanet   neoplanet2  avantgo
-    emacs       mozilla     gecko
-    r1          elinks      netfront
-    mobile_safari
+    ie8         ie9         ie10
+    opera       opera3      opera4
+    opera5      opera6      opera7
+    lynx        links       aol
+    aol3        aol4        aol5
+    aol6        neoplanet   neoplanet2
+    avantgo     emacs       mozilla
+    gecko       r1          elinks
+    netfront    mobile_safari
 );
 
 # Firefox variants
@@ -351,6 +351,7 @@ sub _test {
     $tests->{IE7} = ( $tests->{IE} && $major == 7 );
     $tests->{IE8} = ( $tests->{IE} && $major == 8 );
     $tests->{IE9} = ( $tests->{IE} && $major == 9 );
+    $tests->{IE10} = ( $tests->{IE} && $major == 10 );
 
     # Neoplanet browsers
 
@@ -1367,7 +1368,7 @@ version separately.
 
 =head3 icab
 
-=head3 ie ie3 ie4 ie4up ie5 ie55 ie6 ie7 ie8 ie9
+=head3 ie ie3 ie4 ie4up ie5 ie55 ie6 ie7 ie8 ie9 ie10
 
 =head3 java
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -878,6 +878,26 @@
       "other" : null,
       "version" : "9.0"
    },
+   "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)": {
+      "browser_string": "MSIE",
+      "major" : "10",
+      "match" : [
+         "windows",
+         "win7",
+         "winnt",
+         "win32",
+         "ie",
+         "ie10",
+         "ie55up",
+         "ie5up",
+         "ie4up"
+      ],
+      "minor" : "0",
+      "no_match" : null,
+      "os" : "Win7",
+      "other" : null,
+      "version" : "10.0"
+   },
    "Mozilla/4.0 (compatible; Opera/3.0; Windows 4.10) 3.50" : {
       "browser_string" : "Opera",
       "country" : null,


### PR DESCRIPTION
These commits add the `ie9` and `ie10` methods to detect Internet Explorer 9 and 10, respectively.
