### PR TITLE
Add detections for the Trident engine

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -57,8 +57,13 @@ push @ALL_TESTS, qw(
     aol3        aol4        aol5
     aol6        neoplanet   neoplanet2
     avantgo     emacs       mozilla
-    gecko       r1          elinks
-    netfront    mobile_safari
+    r1          elinks      netfront
+    mobile_safari
+);
+
+# Engines
+push @ALL_TESTS, qw(
+    gecko    trident
 );
 
 # Firefox variants
@@ -695,6 +700,16 @@ sub _test {
         }
     }
 
+    # Engines
+
+    $tests->{TRIDENT} = ( index( $ua, "trident/" ) != -1 );
+
+    $self->{engine_version} = $self->{gecko_version};
+
+    if ( $ua =~ /trident\/([\w\.\d]*)/ ) {
+        $self->{engine_version} = $1;
+    }
+
     # RealPlayer
     $tests->{REALPLAYER}
         = ( index( $ua, "(r1 " ) != -1 || index( $ua, "realplayer" ) != -1 );
@@ -929,6 +944,10 @@ sub engine_string {
         return 'Gecko';
     }
 
+    if ( $self->trident ) {
+        return 'Trident';
+    }
+
     if ( $self->ie ) {
         return 'MSIE';
     }
@@ -944,11 +963,7 @@ sub _engine {
 
     my ( $self, $check ) = _self_or_default( @_ );
 
-    if ( $self->gecko ) {
-        return $self->gecko_version;
-    }
-
-    return;
+    return $self->{engine_version};
 
 }
 
@@ -1300,24 +1315,27 @@ is thrown away.
 
 Returns one of the following:
 
-Gecko, KHTML, MSIE, NetFront
+Gecko, KHTML, Trident, MSIE, NetFront
 
-Returns undef if no string can be found.
+Returns C<undef> if no string can be found.
 
 =head2 engine_version()
 
 Returns the version number of the rendering engine. Currently this only
-returns a version number for Gecko. Returns undef for all other engines.
+returns a version number for Gecko and Trident. Returns C<undef> for all
+other engines.
 
 =head2 engine_major()
 
 Returns the major version number of the rendering engine. Currently this only
-returns a version number for Gecko. Returns undef for all other engines.
+returns a version number for Gecko and Trident. Returns C<undef> for all
+other engines.
 
 =head2 engine_minor()
 
 Returns the minor version number of the rendering engine. Currently this only
-returns a version number for Gecko. Returns undef for all other engines.
+returns a version number for Gecko and Trident. Returns C<undef> for all
+other engines.
 
 =head1 Detecting OS Platform and Version
 
@@ -1593,8 +1611,8 @@ John Oatis
 
 =head1 TO DO
 
-The _engine() method currently only handles Gecko.  It needs to be expanded to
-handle other rendering engines.
+The C<_engine()> method currently only handles Gecko and Trident.  It
+needs to be expanded to handle other rendering engines.
 
 POD coverage is also not 100%.
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -360,6 +360,7 @@
          "winnt",
          "win32",
          "dotnet",
+         "trident",
          "ie",
          "ie8",
          "ie55up",
@@ -373,7 +374,11 @@
       "public_major" : "8",
       "public_minor" : "0",
       "public_version" : "8.0",
-      "version" : "8.0"
+      "version" : "8.0",
+      "engine_major" : "4",
+      "engine_minor" : "0",
+      "engine_version" : "4.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/4.0 (PSP (PlayStation Portable); 2.00)" : {
       "device_name" : "Sony PlayStation Portable",
@@ -714,6 +719,7 @@
          "win32",
          "winnt",
          "dotnet",
+         "trident",
          "ie",
          "ie7",
          "ie4up",
@@ -724,7 +730,11 @@
       "minor" : "0",
       "no_match" : [
          "robot"
-      ]
+      ],
+      "engine_major" : "4",
+      "engine_minor" : "0",
+      "engine_version" : "4.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; FunWebProducts; .NET CLR 1.0.3705; .NET CLR 1.1.4322; Media Center PC 4.0; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648; SeekmoToolbar 4.8.4)" : {
       "browser_string" : "MSIE",
@@ -827,6 +837,7 @@
          "winnt",
          "win32",
          "dotnet",
+         "trident",
          "ie",
          "ie4up",
          "ie55up",
@@ -836,7 +847,11 @@
       "os" : "WinXP",
       "public_major" : "8",
       "public_minor" : "0",
-      "public_version" : "8.0"
+      "public_version" : "8.0",
+      "engine_major" : "4",
+      "engine_minor" : "0",
+      "engine_version" : "4.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NETi CLR 3.0.30729; Media Center PC 6.0; MS-RTC LM 8; InfoPath.3; .NET4.0C) chromeframe/4.0" : {
       "browser_string" : "MSIE",
@@ -847,6 +862,7 @@
          "winnt",
          "win32",
          "dotnet",
+         "trident",
          "ie",
          "ie8",
          "ie55up",
@@ -857,7 +873,11 @@
       "no_match" : null,
       "os" : "Win7",
       "other" : null,
-      "version" : "8.0"
+      "version" : "8.0",
+      "engine_major" : "4",
+      "engine_minor" : "0",
+      "engine_version" : "4.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)": {
       "browser_string": "MSIE",
@@ -867,6 +887,7 @@
          "win7",
          "winnt",
          "win32",
+         "trident",
          "ie",
          "ie9",
          "ie55up",
@@ -877,7 +898,11 @@
       "no_match" : null,
       "os" : "Win7",
       "other" : null,
-      "version" : "9.0"
+      "version" : "9.0",
+      "engine_major" : "5",
+      "engine_minor" : "0",
+      "engine_version" : "5.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)": {
       "browser_string": "MSIE",
@@ -887,6 +912,7 @@
          "win7",
          "winnt",
          "win32",
+         "trident",
          "ie",
          "ie10",
          "ie55up",
@@ -897,7 +923,11 @@
       "no_match" : null,
       "os" : "Win7",
       "other" : null,
-      "version" : "10.0"
+      "version" : "10.0",
+      "engine_major" : "6",
+      "engine_minor" : "0",
+      "engine_version" : "6.0",
+      "engine_string" : "Trident"
    },
    "Mozilla/4.0 (compatible; Opera/3.0; Windows 4.10) 3.50" : {
       "browser_string" : "Opera",
@@ -2336,7 +2366,7 @@
    "RealPlayer SP, Windows 7: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; (R1 1.6))" : {
       "browser_string" : "RealPlayer",
       "country" : null,
-      "engine_string" : "MSIE",
+      "engine_string" : "Trident",
       "language" : null,
       "major" : null,
       "match" : [
@@ -2346,6 +2376,7 @@
          "win32",
          "dotnet",
          "realplayer",
+         "trident",
          "ie",
          "ie7",
          "ie55up",
@@ -2692,6 +2723,7 @@
          "ie55up",
          "ie5up",
          "ie8",
+         "trident",
          "win32",
          "windows",
          "winnt",
@@ -2705,6 +2737,7 @@
          "windows",
          "winphone",
          "mobile",
+         "trident",
          "ie",
          "ie4up",
          "ie55up",
@@ -2722,6 +2755,7 @@
          "windows",
          "winphone",
          "mobile",
+         "trident",
          "ie",
          "ie4up",
          "ie55up",
@@ -2737,7 +2771,7 @@
        "major" : "8",
        "minor" : "0",
        "language" : "EN",
-       "engine_string" : "MSIE",
+       "engine_string" : "Trident",
        "match" : [
          "ie",
          "ie4up",
@@ -2745,6 +2779,7 @@
          "ie5up",
          "ie8",
          "aol",
+         "trident",
          "win32",
          "windows",
          "winnt",
@@ -2755,13 +2790,14 @@
    },
    "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; Crossrider130)" : {
        "browser_string" : "MSIE",
-       "engine_string" : "MSIE",
+       "engine_string" : "Trident",
        "match" : [
          "ie",
          "ie4up",
          "ie55up",
          "ie5up",
          "ie8",
+         "trident",
          "win32",
          "windows",
          "winnt",


### PR DESCRIPTION
Since IE7, Microsoft now gave their rendering engine a name (Trident) and pushes that in the user string. The adds Trident as a known engine next to Gecko.
