### PR TITLE
Removed Duplicate blackberry from @ALL_TESTS

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -58,7 +58,7 @@ push @ALL_TESTS, qw(
     aol6        neoplanet   neoplanet2
     avantgo     emacs       mozilla
     r1          elinks      netfront
-    mobile_safari           blackberry
+    mobile_safari
 );
 
 # Engines


### PR DESCRIPTION
When adding Blackberry to the list of possible browser strings I had
added 'blackberry' to the push section of @ALL_TESTS marked #Browsers.
This led to a warning that an existing reference was
being redefined. Removing the duplicate 'blackberry' from @ALL_tests
(it is pushed earlier in #devices section) removes the warning.
browser_string() will still returns 'BlackBerry' now
using only the single instance of 'blackberry' within @ALL_TESTS.
