### PR TITLE
'jp.co.yahoo.android' is the part of android application id of yahoo.co.jp.

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -407,7 +407,7 @@ sub _test {
     $tests->{GETRIGHT}   = ( index( $ua, "getright" ) != -1 );
     $tests->{LWP}
         = ( index( $ua, "libwww-perl" ) != -1 || index( $ua, "lwp-" ) != -1 );
-    $tests->{YAHOO}  = ( index( $ua, "yahoo" ) != -1 );
+    $tests->{YAHOO}  = ( index( $ua, "yahoo" ) != -1 ) && ( index( $ua, 'jp.co.yahoo.android') == -1 );
     $tests->{GOOGLE} = ( index( $ua, "googlebot" ) != -1 );
     $tests->{GOOGLEMOBILE} = ( index( $ua, "googlebot-mobile" ) != -1 );
     $tests->{MSN} = ( (index( $ua, "msnbot" ) != -1 || index( $ua, "bingbot" )) != -1 );

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2901,6 +2901,23 @@
        ],
        "os" : null,
        "version" : "5.34"
+   },
+   "Mozilla/5.0 (Linux; U; Android 2.1-update1; ja-jp; IS03 Build/S2080) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 YJApp-ANDROID jp.co.yahoo.android.yjtop/1.0.3" : {
+       "browser_string" : "Safari",
+       "match" : [
+         "safari",
+         "linux",
+         "unix",
+         "mobile",
+         "mobile_safari",
+         "android"
+       ],
+       "minor" : ".30",
+       "no_match" : [
+         "robot"
+       ],
+       "os" : "Android",
+       "version" : "5.30"
    }
 }
 


### PR DESCRIPTION
This patch changes the detection of yahoo robot.
Currently, just checking the string "yahoo" for the detection of yahoo robot.
But, 'jp.co.yahoo.android',included in user agent, is the part of android application id of yahoo.co.jp.
For example, jp.co.yahoo.android.yjtop.

So, this patch doesn't regard as robot when the string 'jp.co.yahoo.android' is found.
