### PR TITLE
Warning when UA contains a / in the product name.

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -235,6 +235,7 @@ sub _test {
     # Browser version
     my ( $major, $minor, $beta ) = (
         $ua =~ m{
+            \S+                     # Greedly catch anything leading up to forward slash.
             \/                      # Version starts with a slash
             [A-Za-z]*               # Eat any letters before the major version
             ( [^.]* )               # Major version number is everything before the first dot

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -3036,6 +3036,17 @@
        "public_major" : "1",
        "public_minor" : "0.7412",
        "public_version" : "1.7412"
+   },
+   "Mozilla/DnsHealthCheckBot/1.0" : {
+       "browser_string" : "Netscape",
+       "match" : [
+         "netscape",
+         "robot"
+       ],
+       "os" : null,
+       "public_major" : "1",
+       "public_minor" : "0",
+       "public_version" : "1.0"
    }
 }
 


### PR DESCRIPTION
_Edit:_ The solution to this problem changed as you'll see if you read the comments.

At $work we use perl's -w flag a lot.  While I think this is a bad practice, it is not something I can change quickly.

Due to the -w flag we are getting lots of warnings in our logs from a particular User-Agent:

```
Mozilla/DnsHealthCheckBot/1.0
```

Which is producing this warning:

```
Argument "/1" isn't numeric in numeric eq (==) at HTTP/BrowserDetect.pm line 391.
```

You can reproduce this using the current released version of HTTP::BrowserDetect like this:

``` perl
perl -we 'use HTTP::BrowserDetect; HTTP::BrowserDetect->new("Mozilla/DnsHealthCheckBot/1.0")'
```

The change in this pull request is to add a 'no warnings' line to HTTP::BrowserDetect for those people that are blindly enabling warnings everywhere with the -w flag.

Thanks!
