### PR TITLE
Fix mistaken WAP detection for Nokia Windows Phones

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -539,6 +539,8 @@ sub _test {
 
     $tests->{BLACKBERRY} = ( index( $ua, "blackberry" ) != -1 );
     $tests->{IPHONE}     = ( index( $ua, "iphone" ) != -1 );
+    $tests->{WINCE}      = ( index( $ua, "windows ce" ) != -1 );
+    $tests->{WINPHONE}   = ( index( $ua, "windows phone" ) != -1 );
     $tests->{WEBOS}      = ( index( $ua, "webos" ) != -1 );
     $tests->{IPOD}       = ( index( $ua, "ipod" ) != -1 );
     $tests->{IPAD}       = ( index( $ua, "ipad" ) != -1 );
@@ -546,10 +548,10 @@ sub _test {
     $tests->{AUDREY}     = ( index( $ua, "audrey" ) != -1 );
     $tests->{IOPENER}    = ( index( $ua, "i-opener" ) != -1 );
     $tests->{AVANTGO}    = ( index( $ua, "avantgo" ) != -1 );
-    $tests->{PALM} = ( $tests->{AVANTGO} || index( $ua, "palmos" ) != -1 );
-    $tests->{WAP}
-        = (    index( $ua, "up.browser" ) != -1
-            || index( $ua, "nokia" ) != -1
+    $tests->{PALM}       = ( $tests->{AVANTGO} || index( $ua, "palmos" ) != -1 );
+    $tests->{WAP}        = (
+               index( $ua, "up.browser" ) != -1
+            || ( index( $ua, "nokia" ) != -1 && !$tests->{WINPHONE} )
             || index( $ua, "alcatel" ) != -1
             || index( $ua, "ericsson" ) != -1
             || index( $ua, "sie-" ) == 0
@@ -644,9 +646,6 @@ sub _test {
     $tests->{WINVISTA} = ( index( $ua, "nt 6.0" ) != -1 );
     $tests->{WIN7}     = ( index( $ua, "nt 6.1" ) != -1 );
     $tests->{DOTNET}   = ( index( $ua, ".net clr" ) != -1 );
-
-    $tests->{WINCE}    = ( index( $ua, "windows ce" ) != -1 );
-    $tests->{WINPHONE} = ( index( $ua, "windows phone" ) != -1 );
 
     $tests->{WINME} = ( index( $ua, "win 9x 4.90" ) != -1 );    # whatever
     $tests->{WIN32} = (

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2852,6 +2852,25 @@
        "os_string" : "Windows Phone",
        "device_name" : "HTC T7575"
    },
+   "Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 510)" : {
+       "browser_string": "MSIE",
+       "engine_version": "5.0",
+       "language": null,
+       "match" : [
+         "windows",
+         "winphone",
+         "mobile",
+         "trident",
+         "ie",
+         "ie4up",
+         "ie55up",
+         "ie5up",
+         "ie9"
+       ],
+       "os" : "WinPhone",
+       "os_string" : "Windows Phone",
+       "device_name" : "NOKIA Lumia 510"
+   },
    "Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; 8X)" : {
        "browser_string": "MSIE",
        "engine_version": "6.0",


### PR DESCRIPTION
The WAP detection includes a case where any user agent with `nokia` will be classified as a WAP device. I'm sure this is true, but now they are making Windows Phone devices, so Windows Phone user agents from Nokia phones will be accidentally classified as WAP devices. This changes some stuff around in order to alter the Nokia WAP detection to be if it is Nokia and not Windows Phone.
