### PR TITLE
Distinguish version of Windows Phone

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -18,12 +18,13 @@ our @OS_TESTS = qw(
 
 # More precise Windows
 our @WINDOWS_TESTS = qw(
-    win16 win3x   win31
-    win95 win98   winnt
-    winme win32   win2k
-    winxp win2k3  winvista
-    win7  win8    wince
-    winphone
+    win16    win3x     win31
+    win95    win98     winnt
+    winme    win32     win2k
+    winxp    win2k3    winvista
+    win7     win8      wince
+    winphone winphone7 winphone7_5
+    winphone8
 );
 
 # More precise Mac
@@ -684,6 +685,10 @@ sub _test {
         )
             || index( $ua, "win" ) != -1
     );
+
+    $tests->{WINPHONE7}   = ( index( $ua, "windows phone os 7.0" ) != -1 );
+    $tests->{WINPHONE7_5} = ( index( $ua, "windows phone os 7.5" ) != -1 );
+    $tests->{WINPHONE8}   = ( index( $ua, "windows phone 8.0" ) != -1 );
 
     # Mac operating systems
 
@@ -1439,6 +1444,7 @@ winnt, which is a type of win32)
             win2k winxp win2k3 winvista win7 win8
     wince
     winphone
+        winphone7 winphone7_5 winphone8
 
 =head2 dotnet()
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2847,6 +2847,7 @@
        "match" : [
          "windows",
          "winphone",
+         "winphone7",
          "mobile",
          "trident",
          "ie",
@@ -2865,6 +2866,7 @@
        "match" : [
          "windows",
          "winphone",
+         "winphone7_5",
          "mobile",
          "trident",
          "ie",
@@ -2884,6 +2886,7 @@
        "match" : [
          "windows",
          "winphone",
+         "winphone7_5",
          "mobile",
          "trident",
          "ie",
@@ -2903,6 +2906,7 @@
        "match" : [
          "windows",
          "winphone",
+         "winphone8",
          "mobile",
          "trident",
          "ie",


### PR DESCRIPTION
This adds three new methods to distinguish versions of Windows Phone OS: winphone7, winphone75, and winphone8. These methods are useful for sites sniffing in order to display links to platform applications, as these three OS versions can also be distinguished between on the platform's market for application support.
