### PR TITLE
Enable warnings and trap warnings in tests

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1,4 +1,5 @@
 use strict;
+use warnings;
 
 package HTTP::BrowserDetect;
 
@@ -1409,7 +1410,7 @@ Returns C<undef> if no string can be found.
 
 Returns the version number of the rendering engine. Currently this only
 returns a version number for Gecko and Trident. Returns C<undef> for all
-other engines.
+other engines. The output is simply C<engine_major> added with C<engine_minor>.
 
 =head2 engine_major()
 

--- a/t/01-detect.t
+++ b/t/01-detect.t
@@ -7,6 +7,7 @@ use File::Slurp;
 use FindBin;
 use JSON::PP;
 use Test::More qw( no_plan );
+use Test::NoWarnings;
 
 # test that the module loads without errors
 my $w;

--- a/t/03-language.t
+++ b/t/03-language.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::NoWarnings ();
 use HTTP::BrowserDetect;
 
 
@@ -11,4 +12,5 @@ my $browser = HTTP::BrowserDetect->new( "Mozilla/4.0 (compatible; MSIE 8.0; Wind
 
 ok (!$browser->language, "no language detected");
 diag( $browser->language );
+Test::NoWarnings::had_no_warnings();
 done_testing();

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1464,7 +1464,7 @@
       "engine_major" : "0",
       "engine_minor" : "0.9",
       "engine_string" : "Gecko",
-      "engine_version" : "0.9.2",
+      "engine_version" : "0.9",
       "language" : "EN",
       "major" : "6",
       "match" : [


### PR DESCRIPTION
This enables warnings in `lib/BrowserDetect.pm` and adds `Test::NoWarnings` to the tests. This also fixes one warning in a test and updates the documentation for `engine_version` to note about the behavior.
