### PR TITLE
Fix language/country detection for Safari

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1188,7 +1188,7 @@ sub _language_country {
         {
             return { language => uc $1 };
         }
-        if ( $self->user_agent =~ m/([a-z]{2})-([a-z]{2})/xms ) {
+        if ( $self->user_agent =~ m/\s ([a-z]{2})-([A-Za-z]{2})/xms ) {
             return { language => uc $1, country => uc $2 };
         }
     }

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1102,6 +1102,23 @@
       "other" : null,
       "version" : "5"
    },
+   "Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.2; U; en-NZ) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.40.1 Safari/534.6 TouchPad/1.0" : {
+      "browser_string" : null,
+      "country" : "NZ",
+      "engine_string" : "KHTML",
+      "language" : "EN",
+      "major" : "5",
+      "match" : [
+         "linux",
+         "safari",
+         "unix"
+      ],
+      "minor" : "0.34",
+      "no_match" : null,
+      "os" : null,
+      "other" : null,
+      "version" : "5.34"
+   },
    "Mozilla/5.0 (Linux; U; Android 1.0; en-us; dream) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2" : {
       "country" : "US",
       "engine" : "5.25",


### PR DESCRIPTION
This fixes the language/country detection for Safari browsers by requiring a space before the language code and by allowing the country code to include capital letters. This fixes the HP TouchPad detection reported in #36.
