### PR TITLE
Detect IE on ARM as tablet

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -575,6 +575,7 @@ sub _test {
     
     $tests->{MOBILE} = (
                ( $tests->{FIREFOX} && index( $ua, "mobile" ) != -1 )
+            || ( $tests->{IE} && !$tests->{WINPHONE} && index( $ua, "arm" ) != -1 )
             || index( $ua, "up.browser" ) != -1
             || index( $ua, "nokia" ) != -1
             || index( $ua, "alcatel" ) != -1
@@ -621,6 +622,7 @@ sub _test {
     
     $tests->{TABLET} = (
              index( $ua, "ipad" ) != -1
+            || ( $tests->{IE} && !$tests->{WINPHONE} && index( $ua, "arm" ) != -1 )
             || (index( $ua, "android" ) != -1 && index( $ua, "mobile" ) == -1  && index( $ua, "opera" ) == -1 )
             || index( $ua, "kindle" ) != -1
             || index( $ua, "xoom" ) != -1

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1006,6 +1006,33 @@
       "engine_version" : "6.0",
       "engine_string" : "Trident"
    },
+   "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)": {
+      "browser_string": "MSIE",
+      "major" : "10",
+      "match" : [
+         "ie",
+         "ie10",
+         "ie55up",
+         "ie4up",
+         "ie5up",
+         "mobile",
+         "tablet",
+         "trident",
+         "win32",
+         "win8",
+         "windows",
+         "winnt"
+      ],
+      "minor" : "0",
+      "no_match" : null,
+      "os_string" : "Win8",
+      "other" : null,
+      "version" : "10.0",
+      "engine_major" : "6",
+      "engine_minor" : "0",
+      "engine_version" : "6.0",
+      "engine_string" : "Trident"
+   },
    "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)": {
       "browser_string": "MSIE",
       "major" : "10",


### PR DESCRIPTION
This adds a couple checks such that Internet Explorer running on ARM platforms (excluding Windows Phone) is identified as a tablet system. At this time, only Windows RT would be running Internet Explorer on the ARM platform. User agent strings can be found in documentation at http://msdn.microsoft.com/en-us/library/ie/hh920767(v=vs.85).aspx and tested on a Windows RT device (Surface).

Fixes #53
