### PR TITLE
Add symbian user agent to useragents.json that causes warnings

### DIFF
--- a/t/useragents.json
+++ b/t/useragents.json
@@ -3193,7 +3193,9 @@
      "public_major" : "6",
      "public_minor" : "0",
      "version" : "6"
-  }
+  },
+  "SonyEricssonU1i/R1CA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 model-orange" : {
+   }
 }
 
 


### PR DESCRIPTION
Added a useragent that causes warnings to useragents.json.

Wasn't sure what values to set because Symbian doesn't seem to fit into the existing categories, but this at least makes the test fail with the right problem:
# Failed test 'Caught warning'
# at /home/mstevens/http-browserdetect/.build/rkyoIN6qwK/blib/lib/HTTP/BrowserDetect.pm line 391.
# Warning was 'Argument "1ca; mozilla/5" isn't numeric in numeric eq (==) at /home/mstevens/http-browserdetect/.build/rkyoIN6qwK/blib/lib/HTTP/BrowserDetect.pm line 391.'
# SonyEricssonU1i/R1CA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 model-orange

Bailout called.  Further testing stopped:  Test failed.  BAIL OUT!.
# Tests were run but no plan was declared and done_testing() was not seen.

FAILED--Further testing stopped: Test failed.  BAIL OUT!.
make: **\* [test_dynamic] Error 255
error running make test
