### PR TITLE
Split version parsing into two expressions

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -267,21 +267,14 @@ sub _test {
 
     }
 
-    # IE (and many others ) version
-    if ($ua =~ m{
-                compatible;
-                \s*
-                \w*
-                [\s|\/]
-                [A-Za-z\-\/]*       # Eat any letters before the major version
-                ( [0-9a-zA-Z\.]* )  # Grab everything else and split it later
-                ;
-        }x
-        )
-    {
-        my $match = $1;
-        $match =~ s{[a-zA-Z].*}{}g; # toss the beta version for now
-        ( $major, $minor, $beta ) = split /\./, $match;
+    # IE (and others) version
+    if ( $ua =~ m{\b msie \s ( [0-9\.]+ ) (?: [a-z]+ [a-z0-9]* )? ;}x ) {
+        # Internet Explorer
+        ( $major, $minor, $beta ) = split /\./, $1;
+    }
+    elsif ( $ua =~ m{\b compatible; \s* [\w\-]* / ( [0-9\.]* ) (?: [a-z]+ [a-z0-9\.]* )? ;}x ) {
+        # Generic "compatible" formats
+        ( $major, $minor, $beta ) = split /\./, $1;
 
     }
 
@@ -360,6 +353,7 @@ sub _test {
             && !$tests->{SAFARI}
             && !$tests->{CHROME}
             && index( $ua, "mozilla" ) != -1
+            && index( $ua, "msie" ) == -1
             && index( $ua, "spoofer" ) == -1
             && index( $ua, "compatible" ) == -1
             && index( $ua, "opera" ) == -1

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -956,6 +956,31 @@
       "engine_version" : "4.0",
       "engine_string" : "Trident"
    },
+   "Mozilla/5.0 ( ; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)": {
+      "browser_string": "MSIE",
+      "major" : "9",
+      "match" : [
+         "windows",
+         "win7",
+         "winnt",
+         "win32",
+         "trident",
+         "ie",
+         "ie9",
+         "ie55up",
+         "ie5up",
+         "ie4up"
+      ],
+      "minor" : "0",
+      "no_match" : null,
+      "os" : "Win7",
+      "other" : null,
+      "version" : "9.0",
+      "engine_major" : "5",
+      "engine_minor" : "0",
+      "engine_version" : "5.0",
+      "engine_string" : "Trident"
+   },
    "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)": {
       "browser_string": "MSIE",
       "major" : "9",


### PR DESCRIPTION
This splits a single regular expression that parsed version numbers from the user agent into two, where the first is MSIE-specific and the second is for the generic browsers hiding behind the compatible token. This is a possible solution for parsing out the MSIE version even though the compatible token is mysteriously missing (possibly from some privacy proxy software or something?).

I'm not sure if this is the absolute best way to go about this, but it is something to consider, possibly.

Fixes #10
