### PR TITLE
Fix generic version parsing to not cross white space

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -242,7 +242,7 @@ sub _test {
             \S+                     # Greedly catch anything leading up to forward slash.
             \/                      # Version starts with a slash
             [A-Za-z]*               # Eat any letters before the major version
-            ( [^.]* )               # Major version number is everything before the first dot
+            ( [0-9A-Za-z]* )        # Major version number is everything before the first dot
             \.                      # The first dot
             ( [\d]* )               # Minor version number is every digit after the first dot
             [\d.]*                  # Throw away remaining numbers and dots

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -3260,6 +3260,21 @@
      "public_major" : "6",
      "public_minor" : "0",
      "version" : "6"
+   },
+   "SonyEricssonU1i/R1CA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 model-orange) AppleWebKit/525 (KHTML like Gecko) Version/3.0 Safari/525" : {
+      "browser_string" : "Safari",
+      "engine_string" : "KHTML",
+      "match" : [
+         "device",
+         "mobile",
+         "safari",
+         "wap"
+      ],
+      "major" : "5",
+      "minor" : "0.25",
+      "public_major" : "3",
+      "public_minor" : "0",
+      "version" : "5.25"
   }
 }
 


### PR DESCRIPTION
This tweaks the generic version parsing such that when it is looking for the minor version, it does not include white space and cause it to span multiple tokens in the user agent string.

Fixes #55
Fixes #58
