### PR TITLE
Compare Safari build numbers by parts instead of floats

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1067,12 +1067,12 @@ sub _public {
                 # lower build
 
                 for my $maybe_build (
-                    sort { $b <=> $a }
+                    sort { $self->_cmp_versions($b, $a) }
                     keys %safari_build_to_version
                     )
                 {
                     $version = $safari_build_to_version{$maybe_build}, last
-                        if $build >= $maybe_build;
+                        if $self->_cmp_versions($build, $maybe_build) >= 0;
                 }
             }
             my ( $major, $minor ) = split /\./, $version;
@@ -1084,6 +1084,22 @@ sub _public {
     }
 
     return ( $self->major, $self->minor, $self->beta( $check ) );
+}
+
+sub _cmp_versions {
+    my ( $self, $a, $b ) = @_;
+
+    my @a = split /\./, $a;
+    my @b = split /\./, $b;
+
+    while ( @b ) {
+        return -1 if @a == 0 || $a[0] < $b[0];
+        return  1 if @b == 0 || $b[0] < $a[0];
+        shift @a;
+        shift @b;
+    }
+
+    return @a <=> @b;
 }
 
 sub engine_string {

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1439,6 +1439,20 @@
       "public_minor" : "0",
       "public_version" : "1.0"
    },
+   "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/85.8.5 (KHTML, like Gecko) Safari/85.8.1" : {
+      "browser_string" : "Safari",
+      "match" : [
+         "mac",
+         "macosx",
+         "macppc",
+         "safari"
+      ],
+      "major" : "0",
+      "minor" : "0.85",
+      "public_major" : "1",
+      "public_minor" : "0",
+      "version" : "0.85"
+   },
    "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-US; rv:1.0.2) Gecko/20030208 Netscape/7.02" : {
       "browser_string" : "Netscape",
       "country" : "US",


### PR DESCRIPTION
This changes the way the Safari build numbers are compared to compare each part instead of trying to convert it to a float to compare. This prevents warnings for three-part build numbers and allows three-part build numbers to be added to the look up list in the future.

Fixes #11 (the `line 887` warnings)
Fixes #59
