### PR TITLE
Change semantic of 'return unless' to 'return undef'

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -706,7 +706,7 @@ sub _test {
     $self->_os_tests;
     $self->_robot_tests;
 
-    return unless $self->robot;
+    return undef unless $self->robot;
 
 }
 
@@ -1009,7 +1009,7 @@ sub os_version {
 
 sub browser_string {
     my ( $self ) = _self_or_default( @_ );
-    return unless defined $self->{user_agent};
+    return undef unless defined $self->{user_agent};
 
     return 'Netscape'      if $self->netscape;
     return 'IceWeasel'     if $self->iceweasel;
@@ -1033,12 +1033,12 @@ sub browser_string {
     return 'puf'           if $self->puf;
     return 'NetFront'      if $self->netfront;
     return 'Nintendo 3DS'  if $self->n3ds;
-    return;
+    return undef;
 }
 
 sub os_string {
     my ( $self ) = _self_or_default( @_ );
-    return unless defined $self->{user_agent};
+    return undef unless defined $self->{user_agent};
 
     return 'Win95'                       if $self->win95;
     return 'Win98'                       if $self->win98;
@@ -1062,7 +1062,7 @@ sub os_string {
     return 'Mac OS X'                    if $self->macosx;
     return 'Mac'                         if $self->mac;
     return 'OS2'                         if $self->os2;
-    return;
+    return undef;
 }
 
 sub realplayer {


### PR DESCRIPTION
When called in list context some functions return empty list instead of undefined.  This corrects that oversight.
