### PR TITLE
Add detection for Windows 8.1

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -19,9 +19,9 @@ our @WINDOWS_TESTS = qw(
     win95    win98     winnt
     winme    win32     win2k
     winxp    win2k3    winvista
-    win7     win8      wince
-    winphone winphone7 winphone7_5
-    winphone8
+    win7     win8      win8_0
+    win8_1   wince     winphone
+    winphone7  winphone7_5  winphone8
 );
 
 # More precise Mac
@@ -844,7 +844,9 @@ sub _os_tests {
     $tests->{WIN2K3}   = ( index( $ua, "nt 5.2" ) != -1 );
     $tests->{WINVISTA} = ( index( $ua, "nt 6.0" ) != -1 );
     $tests->{WIN7}     = ( index( $ua, "nt 6.1" ) != -1 );
-    $tests->{WIN8}     = ( index( $ua, "nt 6.2" ) != -1 );
+    $tests->{WIN8_0}   = ( index( $ua, "nt 6.2" ) != -1 );
+    $tests->{WIN8_1}   = ( index( $ua, "nt 6.3" ) != -1 );
+    $tests->{WIN8}     = ( $tests->{WIN8_0} || $tests->{WIN8_1} );
     $tests->{DOTNET}   = ( index( $ua, ".net clr" ) != -1 );
 
     $tests->{WINME} = ( index( $ua, "win 9x 4.90" ) != -1 );    # whatever
@@ -1056,7 +1058,8 @@ sub os_string {
     return 'Win2k3'                      if $self->win2k3;
     return 'WinVista'                    if $self->winvista;
     return 'Win7'                        if $self->win7;
-    return 'Win8'                        if $self->win8;
+    return 'Win8'                        if $self->win8_0;
+    return 'Win8.1'                      if $self->win8_1;
     return 'WinNT'                       if $self->winnt;
     return 'Windows Phone'               if $self->winphone;
     return 'Win3x'                       if $self->win3x;
@@ -1648,7 +1651,9 @@ winnt, which is a type of win32)
     win32
         winme win95 win98
         winnt
-            win2k winxp win2k3 winvista win7 win8
+            win2k winxp win2k3 winvista win7
+            win8
+                win8_0 win8_1
     wince
     winphone
         winphone7 winphone7_5 winphone8
@@ -1689,7 +1694,7 @@ Returns one of the following strings, or undef. This method exists solely for
 compatibility with the L<HTTP::Headers::UserAgent> module.
 
   Win95, Win98, WinNT, Win2K, WinXP, Win2k3, WinVista, Win7, Win8,
-  Windows Phone, Mac, Mac OS X, iOS, Win3x, OS2, Unix, Linux,
+  Win8.1, Windows Phone, Mac, Mac OS X, iOS, Win3x, OS2, Unix, Linux,
   Firefox OS, Playstation 3 GameOS, Playstation Portable GameOS,
   RIM Tablet OS
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1102,6 +1102,7 @@
          "trident",
          "win32",
          "win8",
+         "win8_0",
          "windows",
          "winnt"
       ],
@@ -1121,6 +1122,7 @@
       "match" : [
          "windows",
          "win8",
+         "win8_0",
          "winnt",
          "win32",
          "trident",
@@ -1158,6 +1160,32 @@
       "minor" : "0",
       "no_match" : null,
       "os_string" : "Win7",
+      "other" : null,
+      "version" : "11.0",
+      "engine_major" : "7",
+      "engine_minor" : "0",
+      "engine_version" : "7.0",
+      "engine_string" : "Trident"
+   },
+   "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko": {
+      "browser_string": "MSIE",
+      "major" : "11",
+      "match" : [
+         "windows",
+         "win8",
+         "win8_1",
+         "winnt",
+         "win32",
+         "trident",
+         "ie",
+         "ie11",
+         "ie55up",
+         "ie5up",
+         "ie4up"
+      ],
+      "minor" : "0",
+      "no_match" : null,
+      "os_string" : "Win8.1",
       "other" : null,
       "version" : "11.0",
       "engine_major" : "7",


### PR DESCRIPTION
This adds a new token for Windows 8.1 (`win8_1`) as well as a new token for Windows 8.0 (`win8_0`) so that they can be detected independently but the general token (`win8`) can be used for both.

There were a bunch of differences in the platform that would be useful to detect between for, say, links advertising Windows 8 applications (say the application only worked in Windows 8.1).
