### PR TITLE
Add detection for Majestic-12 bot

### DIFF
--- a/README
+++ b/README
@@ -328,6 +328,7 @@ Detecting Other Devices
    linkexchange
    lwp
    lycos
+   mj12bot
    msn (same as bing)
    puf
    slurp

--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -142,6 +142,7 @@ my %ROBOTS = (
     lotusnotes     => 'Lotus Notes',
     lwp            => 'LWP::UserAgent',
     lycos          => 'Lycos',
+    mj12bot        => 'Majestic-12 DSearch',
     msn            => 'MSN',
     msnmobile      => 'MSN Mobile',
     puf            => 'puf',
@@ -160,7 +161,7 @@ my %ROBOTS = (
 our @ROBOT_TESTS = qw(
     puf          curl        wget
     getright     robot       slurp
-    yahoo
+    yahoo        mj12bot
     altavista    lycos       infoseek
     lwp          webcrawler  linkexchange
     webtv        staroffice
@@ -789,6 +790,7 @@ sub _robot_tests {
     $tests->{LINKEXCHANGE}   = ( index( $ua, "lecodechecker" ) != -1 );
     $tests->{LINKCHECKER}    = ( index( $ua, "linkchecker" ) != -1 );
     $tests->{LYCOS}          = ( index( $ua, "lycos" ) != -1 );
+    $tests->{MJ12BOT}        = ( index( $ua, "mj12bot/" ) != -1 );
     $tests->{PUF}            = ( index( $ua, "puf/" ) != -1 );
     $tests->{SCOOTER}        = ( index( $ua, "scooter" ) != -1 );
     $tests->{SLURP}          = ( index( $ua, "slurp" ) != -1 );
@@ -1918,6 +1920,8 @@ value. This is by no means a complete list of robots that exist on the Web.
 =head3 lwp
 
 =head3 lycos
+
+=head3 mj12bot
 
 =head3 msn (same as bing)
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1094,6 +1094,13 @@
       "engine_version" : "4.0",
       "engine_string" : "Trident"
    },
+   "Mozilla/5.0 (compatible; MJ12bot/v1.4.5; http://www.majestic12.co.uk/bot.php?+)": {
+      "robot_name" : "Majestic-12 DSearch",
+      "match" : [
+        "mj12bot",
+        "robot"
+      ]
+   },
    "Mozilla/5.0 ( ; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)": {
       "browser_string": "MSIE",
       "major" : "9",


### PR DESCRIPTION
This adds support for the Majestic-12 DSearch bot, using the robot name "Majestic-12 DSearch".

Fixes #87
