### PR TITLE
Add detection for Chrome OS

### DIFF
--- a/README
+++ b/README
@@ -190,6 +190,7 @@ Detecting OS Platform and Version
             winphone7 winphone7_5 winphone8
 
   dotnet()
+  chromeos()
   firefoxos()
   mac()
     mac68k macppc macosx ios
@@ -216,7 +217,7 @@ Detecting OS Platform and Version
 
       Win95, Win98, WinNT, Win2K, WinXP, Win2k3, WinVista, Win7, Win8,
       Win8.1, Windows Phone, Mac, Mac OS X, iOS, Win3x, OS2, Unix, Linux,
-      Firefox OS, Playstation 3 GameOS, Playstation Portable GameOS,
+      Chrome OS, Firefox OS, Playstation 3 GameOS, Playstation Portable GameOS,
       RIM Tablet OS, BlackBerry 10
 
 Detecting Browser Vendor

--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -13,6 +13,7 @@ our @OS_TESTS = qw(
     unix    linux vms
     bsd     amiga firefoxos
     bb10    rimtabletos
+    chromeos
 );
 
 # More precise Windows
@@ -987,8 +988,13 @@ sub _os_tests {
     $tests->{FREEBSD} = ( index( $ua, "freebsd" ) != -1 );
     $tests->{BSD}     = ( index( $ua, "bsd" ) != -1 );
     $tests->{X11}     = ( index( $ua, "x11" ) != -1 );
+
+    $tests->{CHROMEOS}
+        = ( $tests->{X11} && index( $ua, "cros" ) != -1 );
+
     $tests->{UNIX}
-        = (    $tests->{X11}
+        = ( !$tests->{CHROMEOS}
+            && ($tests->{X11}
             || $tests->{SUN}
             || $tests->{IRIX}
             || $tests->{HPUX}
@@ -998,7 +1004,7 @@ sub _os_tests {
             || $tests->{RELIANT}
             || $tests->{DEC}
             || $tests->{LINUX}
-            || $tests->{BSD} );
+            || $tests->{BSD} ) );
 
     $tests->{VMS}
         = ( index( $ua, "vax" ) != -1 || index( $ua, "openvms" ) != -1 );
@@ -1114,6 +1120,7 @@ sub os_string {
     return 'Android'                     if $self->android;
     return 'Linux'                       if $self->linux;
     return 'Unix'                        if $self->unix;
+    return 'Chrome OS'                   if $self->chromeos;
     return 'Firefox OS'                  if $self->firefoxos;
     return 'BlackBerry 10'               if $self->bb10;
     return 'RIM Tablet OS'               if $self->rimtabletos;
@@ -1709,6 +1716,8 @@ winnt, which is a type of win32)
 
 =head2 dotnet()
 
+=head2 chromeos()
+
 =head2 firefoxos()
 
 =head2 mac()
@@ -1746,7 +1755,7 @@ compatibility with the L<HTTP::Headers::UserAgent> module.
 
   Win95, Win98, WinNT, Win2K, WinXP, Win2k3, WinVista, Win7, Win8,
   Win8.1, Windows Phone, Mac, Mac OS X, iOS, Win3x, OS2, Unix, Linux,
-  Firefox OS, Playstation 3 GameOS, Playstation Portable GameOS,
+  Chrome OS, Firefox OS, Playstation 3 GameOS, Playstation Portable GameOS,
   RIM Tablet OS, BlackBerry 10
 
 =head1 Detecting Browser Vendor

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2240,6 +2240,20 @@
          "robot"
       ]
    },
+   "Mozilla/5.0 (X11; CrOS x86_64 5841.87.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.0 Safari/537.36": {
+     "major" : "36",
+     "minor" : "0",
+     "match" : [
+       "chrome",
+       "chromeos",
+       "x11"
+     ],
+     "os_string" : "Chrome OS",
+     "public_major" : "36",
+     "public_minor" : "0",
+     "public_version" : "36.0",
+     "version" : "36.0"
+   },
    "Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.7) Gecko/20040619 Firefox/0.9" : {
       "browser_string" : "Firefox",
       "country" : "US",


### PR DESCRIPTION
This adds detection for Chrome OS. This adds a new OS test `chromeos` and set the `os_string` to "Chrome OS".

Fixes #86
