### PR TITLE
Switch to using strings for version numbers.

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -644,7 +644,7 @@ sub _init_core {
             $self->{realplayer_version} = $1;
             ( $self->{major}, $self->{minor} )
                 = split( /\./, $self->{realplayer_version} );
-            $self->{minor} = ".$self->{minor}" if $self->{minor};
+            $self->{minor} = ".$self->{minor}" if defined( $self->{minor} );
         }
         elsif ( $ua =~ /realplayer\s(\w+)/ ) {
             $self->{realplayer_version} = $1;
@@ -1627,7 +1627,7 @@ sub version {
     my ( $self, $check ) = @_;
     $self->_init_version() unless $self->{version_tests};
 
-    my $version = $self->{major} + $self->{minor};
+    my $version = "$self->{major}$self->{minor}";
     if ( defined $check ) {
         return $check
             == $version;    # FIXME unreliable to compare floats for equality
@@ -1668,7 +1668,7 @@ sub public_version {
     my ( $self,  $check ) = @_;
     my ( $major, $minor ) = $self->_public;
 
-    return $major + $minor;
+    return "$major$minor";
 }
 
 sub public_major {
@@ -1735,7 +1735,7 @@ sub _public {
             my ( $major, $minor ) = split /\./, $version;
             my $beta;
             $minor =~ s/(\D.*)// and $beta = $1;
-            $minor = 0 + ( '.' . $minor );
+            $minor = ( '.' . $minor );
             return ( $major, $minor, ( $beta ? 1 : undef ) );
         }
     }


### PR DESCRIPTION
Part of my code uses HTTP::BrowserDetect like this:

```
    my $browser_detect = HTTP::BrowserDetect->new($ua);

    # Browser                                                                                                                                        
    my $browser = 'Unknown';
    $browser = $browser_detect->browser_string() if $browser_detect->browser_string();

    # Append version                                                                                                                                 
    $browser .= ' ' . $browser_detect->public_version() . $browser_detect->public_beta() if $browser_detect->public_version();
```

There's a problem, though, when encountering this user agent (and most other user agents that have .0 as the minor version combined with a beta version):

```
Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36
```

In version 1.75, we returned "Chrome 36" for that user agent. The changes I made added detection of beta versions in some more cases, meaning that `$browser_detect->public_beta()` actually returns something, which actually makes things worse -- now, the code above returns "Chrome 36.1985.67", because the version is `36.0` as a float, which means the `.0` is dropped when it turns back into a string to concatenate with the beta version.

This pull request starts treating version numbers as strings, so that ".0" won't get eaten, so the version numbers can be concatenated with beta strings without causing problems. In this branch, the version number returned by that code is "Chrome 36.0.1985.67".