### PR TITLE
Fixing cases where provided UA is undef result lots of warnings

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -323,7 +323,7 @@ sub new {
         $user_agent = $ENV{'HTTP_USER_AGENT'};
     }
 
-    $self->{user_agent} = $user_agent;
+    $self->{user_agent} = $user_agent // '';
     $self->_init_core;
 
     return $self;

--- a/t/99_blank_ua.t
+++ b/t/99_blank_ua.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More; 
+
+use Test::FailWarnings;
+
+use_ok q{HTTP::BrowserDetect};
+
+ok my $ua = HTTP::BrowserDetect->new(undef) , q{undef produces no warnings};
+
+done_testing();


### PR DESCRIPTION
In code at $work we are running in to cases (generally in our tests) where the passed UA is undef and results in lots of warnings in the logs. Our usecase is leveraging mobile() and tablet() to check the state of the caller. While we have a fix in our code I'm guessing that others might run in to the same issue and it's a simple fix. 