### PR TITLE
Detect more edge

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -512,7 +512,7 @@ sub _init_core {
         $browser_tests->{epiphany} = 1;
     }
     elsif ( $ua
-        =~ m{^mozilla/.+windows (?:nt|phone) \d{2}\.\d+;.+ applewebkit/.+ chrome/.+ safari/.+ edge/[\d.]+$}
+        =~ m{^mozilla/.+windows (?:nt|phone) \d{2}\.\d+;?.+ applewebkit/.+ chrome/.+ safari/.+ edge/[\d.]+$}
         ) {
         $browser        = 'edge';
         $browser_string = 'Edge';

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2649,6 +2649,48 @@
       "public_version" : "29.0",
       "version" : "29.0"
    },
+   "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586" : {
+      "browser" : "edge",
+      "browser_string" : "Edge",
+      "engine" : "edgehtml",
+      "engine_beta" : "",
+      "engine_major" : "13",
+      "engine_minor" : ".10586",
+      "engine_string" : "EdgeHTML",
+      "match" : [
+         "edge",
+         "edgehtml",
+         "windows",
+         "win32",
+         "winnt",
+         "win10",
+         "win10_0"
+      ],
+      "os" : "windows",
+      "os_string" : "Win10.0",
+      "robot" : 0
+   },
+   "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240" : {
+      "browser" : "edge",
+      "browser_string" : "Edge",
+      "engine" : "edgehtml",
+      "engine_beta" : "",
+      "engine_major" : "12",
+      "engine_minor" : ".10240",
+      "engine_string" : "EdgeHTML",
+      "match" : [
+         "edge",
+         "edgehtml",
+         "windows",
+         "win32",
+         "winnt",
+         "win10",
+         "win10_0"
+      ],
+      "os" : "windows",
+      "os_string" : "Win10.0",
+      "robot" : 0
+   },
    "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0" : {
       "browser" : "edge",
       "browser_string" : "Edge",


### PR DESCRIPTION
When parsing my web server's log files, I noticed a few obviously Edge browsers misclassified as Chrome, such as:

    Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586

This was due to a hard-coded semicolon in the browser detection regex for Edge.

Making the semicolon optional for that regex causes all tests to pass, and adds support for the weird ones I encountered. Those have also been added to the test suite.