### PR TITLE
recognise & test Edge browsers "via google translate"

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -467,7 +467,7 @@ sub _init_core {
     # Detect engine
     $self->{engine_version} = undef;
 
-    if ( $ua =~ m{edge/([\d.]+)$} ) {
+    if ( $ua =~ m{edge/([\d.]+)(?:,gzip\(gfe\))?$} ) {
         $tests->{edgehtml}      = 1;
         $self->{engine_version} = $1;
     }
@@ -512,7 +512,7 @@ sub _init_core {
         $browser_tests->{epiphany} = 1;
     }
     elsif ( $ua
-        =~ m{^mozilla/.+windows (?:nt|phone) \d{2}\.\d+;?.+ applewebkit/.+ chrome/.+ safari/.+ edge/[\d.]+$}
+        =~ m{^mozilla/.+windows (?:nt|phone) \d{2}\.\d+;?.+ applewebkit/.+ chrome/.+ safari/.+ edge/[\d.]+(?:,gzip\(gfe\))?$}
         ) {
         $browser        = 'edge';
         $browser_string = 'Edge';

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2712,6 +2712,27 @@
       "os_string" : "Win10.0",
       "robot" : 0
    },
+   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586,gzip(gfe)" : {
+      "browser" : "edge",
+      "browser_string" : "Edge",
+      "engine" : "edgehtml",
+      "engine_beta" : "",
+      "engine_major" : "13",
+      "engine_minor" : ".10586",
+      "engine_string" : "EdgeHTML",
+      "match" : [
+         "edge",
+         "edgehtml",
+         "windows",
+         "win32",
+         "winnt",
+         "win10",
+         "win10_0"
+      ],
+      "os" : "windows",
+      "os_string" : "Win10.0",
+      "robot" : 0
+   },
    "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" : {
       "browser" : "ie",
       "browser_string" : "MSIE",


### PR DESCRIPTION
i.e. the following:

    Mozilla/5.0 (Windows NT 10.0 ... /537.36 Edge/13.10586,gzip(gfe)

is an Edge browser, not Chrome.

The ",gzip(gfe)" is added when a user uses Google Translate to look at a
page, i.e. by inserting a page's URL into Google Translate and clicking
the Translate button.

This behaviour ("it" adding ",gzip(gfe)") can be shown on any website
that shows you your user-agent. Take a Cloudflare's "trace" page, such
as

    http://www.theregister.co.uk/cdn-cgi/trace

Stick that into https://translate.google.com/ and click "Translate"

You will then notice your user-agent string has had the ",gzip(gfe)"
appended to it, when Google made the request in your stead.