### PR TITLE
Fix google translate

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -455,6 +455,9 @@ sub _init_core {
 
     my $ua = lc $self->{user_agent};
 
+    # any UA via Google Translate gets this appended
+    $ua =~ s{,gzip\(gfe\)\z}{};
+
     # These get filled in immediately
     $self->{tests}         = {};
     $self->{browser_tests} = {};

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2712,6 +2712,27 @@
       "os_string" : "Win10.0",
       "robot" : 0
    },
+   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586,gzip(gfe)" : {
+      "browser" : "edge",
+      "browser_string" : "Edge",
+      "engine" : "edgehtml",
+      "engine_beta" : "",
+      "engine_major" : "13",
+      "engine_minor" : ".10586",
+      "engine_string" : "EdgeHTML",
+      "match" : [
+         "edge",
+         "edgehtml",
+         "windows",
+         "win32",
+         "winnt",
+         "win10",
+         "win10_0"
+      ],
+      "os" : "windows",
+      "os_string" : "Win10.0",
+      "robot" : 0
+   },
    "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko" : {
       "browser" : "ie",
       "browser_string" : "MSIE",


### PR DESCRIPTION
Rather than fixing Edge only, ensure all browsers get the `,gzip(gfe)` stripped off, before processing is started.

Please double check this is the right place to do it… tests pass, but it hasn't been proven correct!
