### PR TITLE
Make "mobile" false when "tablet" is true

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1787,12 +1787,46 @@ sub _init_device {
         $device_tests->{$device} = 1;
     }
 
-    $device_tests->{mobile} = (
-        ( $browser_tests->{firefox} && index( $ua, "mobile" ) != -1 )
+    $device_tests->{tablet} = (
+        index( $ua, "ipad" ) != -1
             || ( $browser_tests->{ie}
             && index( $ua, "windows phone" ) == -1
             && index( $ua, "arm" ) != -1 )
-            || index( $ua, "windows phone" ) != -1
+            || ( index( $ua, "android" ) != -1
+            && index( $ua, "mobile" ) == -1
+            && index( $ua, "safari" ) != -1 )
+            || ( $browser_tests->{firefox} && index( $ua, "tablet" ) != -1 )
+            || index( $ua, "kindle" ) != -1
+            || index( $ua, "xoom" ) != -1
+            || index( $ua, "flyer" ) != -1
+            || index( $ua, "jetstream" ) != -1
+            || index( $ua, "transformer" ) != -1
+            || index( $ua, "novo7" ) != -1
+            || index( $ua, "an10g2" ) != -1
+            || index( $ua, "an7bg3" ) != -1
+            || index( $ua, "an7fg3" ) != -1
+            || index( $ua, "an8g3" ) != -1
+            || index( $ua, "an8cg3" ) != -1
+            || index( $ua, "an7g3" ) != -1
+            || index( $ua, "an9g3" ) != -1
+            || index( $ua, "an7dg3" ) != -1
+            || index( $ua, "an7dg3st" ) != -1
+            || index( $ua, "an7dg3childpad" ) != -1
+            || index( $ua, "an10bg3" ) != -1
+            || index( $ua, "an10bg3dt" ) != -1
+            || index( $ua, "opera tablet" ) != -1
+            || index( $ua, "rim tablet" ) != -1
+            || index( $ua, "hp-tablet" ) != -1
+    );
+
+    if( !$device_tests->{tablet} )
+    {
+	$device_tests->{mobile} = (
+	    ( $browser_tests->{firefox} && index( $ua, "mobile" ) != -1 )
+	    || ( $browser_tests->{ie}
+		 && index( $ua, "windows phone" ) == -1
+		 && index( $ua, "arm" ) != -1 )
+	    || index( $ua, "windows phone" ) != -1
             || index( $ua, "up.browser" ) != -1
             || index( $ua, "nokia" ) != -1
             || index( $ua, "alcatel" ) != -1
@@ -1838,39 +1872,8 @@ sub _init_device {
             || index( $ua, "googlebot-mobile" ) != -1
             || index( $ua, "msnbot-mobile" ) != -1
             || index( $ua, "bingbot-mobile" ) != -1
-    );
-
-    $device_tests->{tablet} = (
-        index( $ua, "ipad" ) != -1
-            || ( $browser_tests->{ie}
-            && index( $ua, "windows phone" ) == -1
-            && index( $ua, "arm" ) != -1 )
-            || ( index( $ua, "android" ) != -1
-            && index( $ua, "mobile" ) == -1
-            && index( $ua, "safari" ) != -1 )
-            || ( $browser_tests->{firefox} && index( $ua, "tablet" ) != -1 )
-            || index( $ua, "kindle" ) != -1
-            || index( $ua, "xoom" ) != -1
-            || index( $ua, "flyer" ) != -1
-            || index( $ua, "jetstream" ) != -1
-            || index( $ua, "transformer" ) != -1
-            || index( $ua, "novo7" ) != -1
-            || index( $ua, "an10g2" ) != -1
-            || index( $ua, "an7bg3" ) != -1
-            || index( $ua, "an7fg3" ) != -1
-            || index( $ua, "an8g3" ) != -1
-            || index( $ua, "an8cg3" ) != -1
-            || index( $ua, "an7g3" ) != -1
-            || index( $ua, "an9g3" ) != -1
-            || index( $ua, "an7dg3" ) != -1
-            || index( $ua, "an7dg3st" ) != -1
-            || index( $ua, "an7dg3childpad" ) != -1
-            || index( $ua, "an10bg3" ) != -1
-            || index( $ua, "an10bg3dt" ) != -1
-            || index( $ua, "opera tablet" ) != -1
-            || index( $ua, "rim tablet" ) != -1
-            || index( $ua, "hp-tablet" ) != -1
-    );
+	);
+    }
 
     if ( $browser_tests->{obigo} && $ua =~ /^(mot-[^ \/]+)/ ) {
         $device_string = substr $self->{user_agent}, 0, length $1;
@@ -2622,7 +2625,12 @@ format is the same as for the browser_version() functions.
 
 =head2 mobile()
 
-Returns true if the browser appears to belong to a handheld device.
+Returns true if the browser appears to belong to a mobile phone or
+similar device (i.e. one small enough that the mobile version of a
+page is probably preferable over the desktop version).
+
+In previous versions, tablet devices sometimes had mobile() return
+true. They are now mutually exclusive.
 
 =head2 tablet()
 

--- a/t/more-useragents.json
+++ b/t/more-useragents.json
@@ -99,7 +99,6 @@
          "ios",
          "ipad",
          "lib",
-         "mobile",
          "tablet"
       ],
       "minor" : ".0",
@@ -430,7 +429,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari"
       ],
@@ -6002,7 +6000,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -6266,7 +6263,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -6294,7 +6290,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -6322,7 +6317,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -6377,7 +6371,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -7128,7 +7121,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -7156,7 +7148,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -7184,7 +7175,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -7674,7 +7664,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -8270,7 +8259,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -8501,7 +8489,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -8616,7 +8603,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "webkit",
          "silk"
@@ -8650,7 +8636,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "silk",
          "webkit"
@@ -8678,7 +8663,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "webkit",
          "silk"
@@ -8712,7 +8696,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "silk",
          "webkit"
@@ -9611,7 +9594,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -9727,7 +9709,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "silk",
          "webkit"
@@ -9756,7 +9737,6 @@
       "match" : [
          "device",
          "android",
-         "mobile",
          "tablet",
          "silk",
          "webkit"
@@ -16648,7 +16628,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16676,7 +16655,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16704,7 +16682,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16733,7 +16710,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -16766,7 +16742,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16794,7 +16769,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16823,7 +16797,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -16856,7 +16829,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16884,7 +16856,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16913,7 +16884,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -16946,7 +16916,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -16975,7 +16944,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -17009,7 +16977,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -17043,7 +17010,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -17077,7 +17043,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -17111,7 +17076,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit",
          "safari"
@@ -17144,7 +17108,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "webkit"
       ],
@@ -17175,7 +17138,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "chrome",
          "webkit"
@@ -17203,7 +17165,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -17233,7 +17194,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -17263,7 +17223,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"
@@ -17895,7 +17854,6 @@
          "device",
          "ios",
          "ipad",
-         "mobile",
          "tablet",
          "safari",
          "webkit"

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -1910,7 +1910,6 @@
       "language" : "EN",
       "major" : "5",
       "match" : [
-         "mobile",
          "device",
          "safari",
          "tablet",
@@ -2567,7 +2566,6 @@
       "match" : [
          "blackberry",
          "device",
-         "mobile",
          "rimtabletos",
          "webkit",
          "tablet"
@@ -4090,7 +4088,6 @@
          "ie55up",
          "ie4up",
          "ie5up",
-         "mobile",
          "tablet",
          "trident",
          "win32",
@@ -4348,7 +4345,6 @@
       "major" : "5",
       "match" : [
          "safari",
-         "mobile",
          "ios",
          "ipad",
          "tablet",
@@ -4379,7 +4375,6 @@
       "engine_version" : "534.12",
       "ios" : 1,
       "match" : [
-         "mobile",
          "ios",
          "ipad",
          "mobile_safari",
@@ -4884,7 +4879,6 @@
       "language" : "EN",
       "major" : "11",
       "match" : [
-         "mobile",
          "tablet",
          "win32",
          "windows",


### PR DESCRIPTION
I have a proposed solution to issue #90 -- make "mobile" indicate true when the mobile version of a page is preferable, and false otherwise. This involves a significant change, of course, making "mobile" false on tablet devices, when it's generally (but not always) true right now. I feel like this is a consistent and correct way to behave, though; it's consistent and simple to understand when people think about the tablet case, and generally gives correct behavior when people don't think about the tablet case. The behavior we have now breaks in the common case where the user of HTTP::BrowserDetect doesn't think about tablets (they wind up giving the mobile version of the page to tablet users, which in most cases is undesired).