### PR TITLE
Add an explicit test for Kindle Fire

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension HTTP::BrowserDetect.
 
 {{$NEXT}}
+    - Add a test for Kindle Fire (andrewmoise)
 
 3.10 2016-03-29 22:15:35 America/Toronto
     - Big change: Add robot version detection, distinct from browser

--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -59,7 +59,7 @@ our @GAMING_TESTS = qw(
 # Device related tests
 our @DEVICE_TESTS = qw(
     android audrey blackberry dsi iopener ipad
-    iphone ipod kindle n3ds palm ps3 psp wap webos
+    iphone ipod kindle kindlefire n3ds palm ps3 psp wap webos
     mobile tablet
 );
 
@@ -2062,6 +2062,7 @@ sub _init_device {
             my $model = $1;
             if ( $model =~ m{^KF} ) {
                 $device_string = "Android tablet (Kindle Fire)";
+		$device_tests->{kindlefire} = 1;
             }
             else {
                 $device_string = "Android tablet ($model)";
@@ -3070,6 +3071,8 @@ The following methods are available, each returning a true or false value.
 =head3 ipad
 
 =head3 kindle
+
+=head3 kindlefire
 
 =head3 n3ds
 

--- a/t/more-useragents.json
+++ b/t/more-useragents.json
@@ -8952,7 +8952,8 @@
          "android",
          "tablet",
          "webkit",
-         "silk"
+         "silk",
+         "kindlefire"
       ],
       "minor" : ".45",
       "os" : "android",
@@ -8986,7 +8987,8 @@
          "android",
          "tablet",
          "silk",
-         "webkit"
+         "webkit",
+         "kindlefire"
       ],
       "os" : "android",
       "os_beta" : ".3",
@@ -9014,7 +9016,8 @@
          "android",
          "tablet",
          "webkit",
-         "silk"
+         "silk",
+         "kindlefire"
       ],
       "minor" : ".44",
       "os" : "android",
@@ -9048,7 +9051,8 @@
          "android",
          "tablet",
          "silk",
-         "webkit"
+         "webkit",
+         "kindlefire"
       ],
       "os" : "android",
       "os_beta" : ".3",
@@ -10117,7 +10121,8 @@
          "android",
          "tablet",
          "silk",
-         "webkit"
+         "webkit",
+         "kindlefire"
       ],
       "os" : "android",
       "os_beta" : ".3",
@@ -10147,7 +10152,8 @@
          "android",
          "tablet",
          "silk",
-         "webkit"
+         "webkit",
+         "kindlefire"
       ],
       "os" : "android",
       "os_beta" : ".3",


### PR DESCRIPTION
Adds a test for indicating to the user when we've detected a Kindle Fire tablet.