### PR TITLE
Define exceptions for ROBOT_FRAGMENTS (fix for #136)

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1006,6 +1006,10 @@ my @ROBOT_FRAGMENTS = qw(
     zyborg
 );
 
+my %ROBOT_FRAGMENT_EXCEPTIONS = (
+    bot => ['cubot'],
+);
+
 sub _init_robots {
     my $self = shift;
 
@@ -1277,7 +1281,16 @@ sub _init_robots {
     }
     else {
         # See if we have a simple fragment
+        FRAGMENT:
         for my $fragment (@ROBOT_FRAGMENTS) {
+            if ( $ROBOT_FRAGMENT_EXCEPTIONS{$fragment} ) {
+                for my $exception ( @{ $ROBOT_FRAGMENT_EXCEPTIONS{$fragment} || [] } ) {
+                    if ( index( $ua, $exception ) != -1 ) {
+                        next FRAGMENT;
+                    }
+                }
+            }
+
             if ( index( $ua, $fragment ) != -1 ) {
                 $robot_fragment = $fragment;
                 $robot_tests->{robot} = 'unknown';

--- a/t/more-useragents.json
+++ b/t/more-useragents.json
@@ -8330,6 +8330,34 @@
       "os_version" : "4.4",
       "robot" : null
    },
+   "Mozilla/5.0 (Linux; Android 5.1; CUBOT_NOTE_S Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36" : {
+      "browser" : "chrome",
+      "browser_beta" : ".2357.93",
+      "browser_major" : "43",
+      "browser_minor" : ".0",
+      "browser_string" : "Chrome",
+      "device" : "android",
+      "device_string" : "Android (CUBOT_NOTE_S)",
+      "engine" : "webkit",
+      "engine_beta" : "",
+      "engine_major" : "537",
+      "engine_minor" : ".36",
+      "engine_string" : "WebKit",
+      "engine_version" : "537.36",
+      "match" : [
+         "device",
+         "android",
+         "mobile",
+         "chrome",
+         "webkit"
+      ],
+      "os" : "android",
+      "os_major" : "5",
+      "os_minor" : ".1",
+      "os_string" : "Android",
+      "os_version" : "5.1",
+      "robot" : null
+   },
    "Mozilla/5.0 (Linux; Android 4.4.4; XT1254 Build/SU2-12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36" : {
       "browser" : "chrome",
       "browser_beta" : ".2214.109",


### PR DESCRIPTION
Some devices have fragments in their names that are also ROBOT_FRAGMENTS. Hence it should be possible to define exceptions.