### PR TITLE
faster edge test

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -676,7 +676,7 @@ sub _init_core {
         $browser_tests->{epiphany} = 1;
     }
     elsif ( $ua
-        =~ m{^mozilla/.+windows (?:nt|phone) \d{2}\.\d+;?.+ applewebkit/.+ chrome/.+ safari/.+ edge/[\d.]+$}
+        =~ m{^mozilla/[\d.]+ [(]windows (?:nt|phone) \d{2}\..+?[)] applewebkit/[\d.]+ [(]khtml,? like gecko[)] chrome/[\d.]+ (?:mobile )?safari/[\d.]+ edge/[\d.]+$}
     ) {
         $browser        = 'edge';
         $browser_string = 'Edge';


### PR DESCRIPTION
... at the expense of being a little less accurate.

All tests pass.

On the pathological string described on:

    https://github.com/oalders/http-browserdetect/issues/155

... this makes a HTTP::BrowserDetect->new($ua) on that long UA string
complete in a reasonable time.

----

This isn't as good a regex as I'd hoped, but I can't come up with a better one while also supporting Perl 5.8.8.