### PR TITLE
Remove a near duplicate regex

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -2280,13 +2280,9 @@ sub _init_device {
         );
     }
 
-    if (
-        $browser_tests->{ucbrowser}
-        && ( $self->{user_agent}
-            =~ m{ucweb/2.0\s*\(([^\;\)]*\;){4}\s*([^\;\)]*?)\s*\)}i
-            || $self->{user_agent}
-            =~ m{ucweb/2.0\s*\(([^\;\)]*\;){3}\s*([^\;\)]*?)\s*\)}i )
-    ) {
+    if (   $browser_tests->{ucbrowser}
+        && $self->{user_agent}
+        =~ m{ucweb/2.0\s*\(([^\;\)]*\;){3,4}\s*([^\;\)]*?)\s*\)}i ) {
         $device_string = $2;
     }
     elsif ( $ua =~ /^(\bmot-[^ \/]+)/ ) {


### PR DESCRIPTION
This regex is relatively slow in our profiling, and it is doing almost
the same regex twice.

This was added in [this commit](https://github.com/oalders/http-browserdetect/commit/80a406be0a5fde241a05dc442b52bee6da09c6bf). Unfortunately, this code doesn't seem to be tested.