### PR TITLE
Yahoo iOS App as not a robot

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1047,7 +1047,7 @@ sub _init_robots {
         $robot_tests->{yahoo} = 1;
     }
     elsif (index( $ua, 'yahoo' ) != -1
-        && index( $ua, 'jp.co.yahoo.android' ) == -1 ) {
+        && index( $ua, 'jp.co.yahoo' ) == -1 ) {
         $r = 'yahoo';
     }
     elsif ( index( $ua, 'msnbot-mobile' ) != -1 ) {

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -7008,5 +7008,36 @@
       "robot_string" : "puf",
       "robot_version" : "0.93",
       "version" : "0.93"
-   }
+   },
+   "Mozilla/5.0 (iPhone; CPU iPhone OS 14_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 YJApp-IOS jp.co.yahoo.BasePlayer/3.149.0" : {
+      "browser" : "safari",
+      "browser_string" : "Safari",
+      "country" : null,
+      "device" : "iphone",
+      "device_string" : "iPhone",
+      "engine" : "webkit",
+      "engine_beta" : ".15",
+      "engine_major" : "605",
+      "engine_minor" : ".1",
+      "engine_string" : "WebKit",
+      "engine_version" : "605.1",
+      "language" : null,
+      "match" : [
+         "safari",
+         "mobile",
+         "iphone",
+         "webkit",
+         "device",
+         "ios"
+      ],
+      "no_match" : [
+         "robot"
+      ],
+      "os" : "ios",
+      "os_beta" : ".1",
+      "os_major" : "14",
+      "os_minor" : ".5",
+      "os_string" : "iOS",
+      "os_version" : "14.5"
+    }
 }


### PR DESCRIPTION
This change treats Yahoo iOS App as not a robot.

Currently, Yahoo iOS App (user agent including `jp.co.yahoo`) is detected as a robot.
But, user agent including `jp.co.yahoo` is a part of Yahoo applicaitons.
For example, `jp.co.yahoo.BasePlayer` or `jp.co.yahoo.ipn.appli`.

So, this change will ensure that Yahoo applications are not considered robots.