### PR TITLE
detect Firefox for iOS

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -110,6 +110,7 @@ our @NETSCAPE_TESTS = qw(
 our @FIREFOX_TESTS = qw(
     firebird    iceweasel   phoenix
     namoroka
+    fxios
 );
 
 # Engine tests
@@ -697,7 +698,7 @@ sub _init_core {
     }
     elsif (
         $ua =~ m{
-                (firebird|iceweasel|phoenix|namoroka|firefox)
+                (firebird|iceweasel|phoenix|namoroka|firefox|fxios)
                 \/
                 ( [^.]* )           # Major version number is everything before first dot
                 \.                  # The first dot
@@ -709,7 +710,7 @@ sub _init_core {
         # Browser is Firefox, possibly under an alternate name
 
         $browser        = 'firefox';
-        $browser_string = ucfirst $1;
+        $browser_string = ucfirst( $1 eq 'fxios' ? $browser : $1 );
 
         $browser_tests->{$1} = 1;
         $browser_tests->{firefox} = 1;
@@ -1879,6 +1880,9 @@ sub _init_version {
                 $beta  = ".$safari_minor" if $safari_minor;
             }
         }
+    }
+    elsif ( $browser_tests->{fxios} ) {
+        ( $major, $minor ) = $ua =~ m{ \b fxios/ (\d+) [.] (\d+) }x;
     }
     elsif ( $browser_tests->{ie} ) {
 

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -7058,4 +7058,33 @@
       "robot_version" : "0.93",
       "version" : "0.93"
    }
+   ,"Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/103.1  Mobile/15E148 Safari/605.1.15" : {
+      "browser" : "firefox",
+      "browser_string" : "Firefox",
+      "device" : "iphone",
+      "device_string" : "iPhone",
+      "engine_beta" : ".15",
+      "engine_string" : "WebKit",
+      "engine_version" : "605.1",
+      "engine" : "webkit",
+      "language" : null,
+      "major" : "103",
+      "minor" : ".1",
+      "match" : [
+         "device",
+         "firefox",
+         "fxios",
+         "ios",
+         "iphone",
+         "mobile",
+         "webkit"
+      ],
+      "os" : "ios",
+      "os_beta" : ".1",
+      "os_major" : "15",
+      "os_minor" : ".6",
+      "os_string" : "iOS",
+      "os_version" : "15.6",
+      "version" : "103.1"
+   }
 }


### PR DESCRIPTION
Firefox for iOS is currently mis-detected as _Safari v2.0_.
This change minds `FxiOS/X.Y`, turning detection into _Firefox vX.Y_.