### PR TITLE
Add Chromecast detection

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -2387,6 +2387,10 @@ sub _init_device {
         =~ /\b((alcatel|huawei|lg|nokia|samsung|sonyericsson)[\w\-]*)\//i ) {
         $device_string = $1;
     }
+    elsif ($self->{user_agent} =~ /CrKey/) {
+        $device = 'chromecast';
+        $device_string = 'Chromecast';
+    }
     elsif ($device) {
         $device_string = $DEVICE_NAMES{$device};
     }

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -7086,5 +7086,23 @@
       "robot_string" : "puf",
       "robot_version" : "0.93",
       "version" : "0.93"
+   },
+   "Mozilla/5.0 (CrKey armv7l 1.5.16041) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.0 Safari/537.36" : {
+      "browser" : "chrome",
+      "browser_string" : "Chrome",
+      "device" : "chromecast",
+      "device_string" : "Chromecast",
+      "match" : [
+         "chrome",
+         "device",
+         "webkit"
+      ],
+      "engine" : "webkit",
+      "engine_minor" : ".36",
+      "engine_major" : "537",
+      "engine_string" : "WebKit",
+      "no_match" : [
+         "robot"
+      ]
    }
 }


### PR DESCRIPTION
This change enables detection for Chromecast.

* If the user agent contains `CrKey`, it is considered to be a Chromecast. (Based on https://github.com/google/closure-library/blob/72ab88a27c1c314fcf3f977071d4c2610da146f2/closure/goog/labs/useragent/platform.js#L140-L144)
* User agent for testing is referenced from https://github.com/google/closure-library/blob/91f1ccfa6b724e085407d7d8f86ad9af82cdd064/closure/goog/labs/useragent/test_agents.js#L462-L464