### PR TITLE
Match iOS by `iPod|iPhone|iPad` with word boundary

### DIFF
--- a/lib/HTTP/BrowserDetect.pm
+++ b/lib/HTTP/BrowserDetect.pm
@@ -1600,9 +1600,7 @@ sub _init_os {
             $os_tests->{macppc} = 1;
         }
     }
-    elsif (index( $ua, 'ipod' ) != -1
-        || index( $ua, 'iphone' ) != -1
-        || index( $ua, 'ipad' ) != -1 ) {
+    elsif ( $ua =~ m{\b(ipad|iphone|ipod)\b} ) {
 
         # iOS
         $os = 'ios';

--- a/t/useragents.json
+++ b/t/useragents.json
@@ -2050,6 +2050,21 @@
          "webkit"
       ]
    },
+   "Mozilla/5.0 (Linux; Android 10; HiPad X Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/110.0.5481.154 Safari/537.36" : {
+      "match" : [
+         "android",
+         "chrome",
+         "device",
+         "tablet",
+         "webkit"
+      ],
+      "os" : "android",
+      "os_beta" : "",
+      "os_major" : "10",
+      "os_minor" : "",
+      "os_string" : "Android",
+      "os_version" : "10"
+   },
    "Mozilla/5.0 (Linux; Android 12; SM-A127F Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/108.0.5359.128 Mobile Safari/537.36[FBAN/EMA;FBLC/ro_RO;FBAV/334.0.0.17.101;]" : {
       "browser" : "facebook_lite",
       "browser_beta" : ".0.17.101",


### PR DESCRIPTION
This User-Agent is judged as `iOS` due to the name `HiPad` and following code.

```
Mozilla/5.0 (Linux; Android 10; HiPad X Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/110.0.5481.154 Safari/537.36
```

https://github.com/oalders/http-browserdetect/blob/88eef264de6288a25387d110540c005a1c861e27/lib/HTTP/BrowserDetect.pm#L1603-L1610

This could be solved by matching with word boundary around `iPod|iPhone|iPad`.

P.S.
I have not found much information besides that HiPad is an Android pad device made by CHUWI.
https://www.chuwi.com/product/items/chuwi-hipad-pro.html

I also thought about changing the order of Android and iOS in `_init_os`, but that would judged it as Android but was not a fundamental solution.