### PR TITLE
Use Test::More first, fixes too many test errors

### DIFF
--- a/t/01-detect.t
+++ b/t/01-detect.t
@@ -12,7 +12,6 @@ use Test::More import =>
     [qw( cmp_ok diag done_testing is is_deeply ok subtest )];
 use Test::Warnings;
 
-
 # test that the module loads without errors
 my $w;
 {

--- a/t/01-detect.t
+++ b/t/01-detect.t
@@ -8,9 +8,10 @@ use JSON::PP          ();
 use List::Util 1.49   qw( uniq );
 use Path::Tiny        qw( path );
 use Test::Differences qw( eq_or_diff );
-use Test::Warnings;
 use Test::More import =>
     [qw( cmp_ok diag done_testing is is_deeply ok subtest )];
+use Test::Warnings;
+
 
 # test that the module loads without errors
 my $w;

--- a/t/04-random-order.t
+++ b/t/04-random-order.t
@@ -6,8 +6,8 @@ use warnings;
 use FindBin    ();
 use JSON::PP   ();
 use Path::Tiny qw( path );
-use Test::Warnings;
 use Test::More import => [qw( cmp_ok done_testing is_deeply ok subtest )];
+use Test::Warnings;
 
 # test that the module loads without errors
 my $w;

--- a/t/99-warnings.t
+++ b/t/99-warnings.t
@@ -4,8 +4,8 @@ use strict;
 use warnings;
 
 use HTTP::BrowserDetect ();
-use Test::Warnings;
 use Test::More import => [qw( done_testing is ok subtest )];
+use Test::Warnings;
 
 ok( my $ua = HTTP::BrowserDetect->new(undef), 'undef produces no warnings' );
 


### PR DESCRIPTION
Prior to change saw test failures looking like this:

t/99-warnings.t ...... 1/? # Looks like you planned 2 tests but ran 3. t/99-warnings.t ...... Dubious, test returned 255 (wstat 65280, 0xff00)

on perl 5.34.0 on ubuntu.